### PR TITLE
Improve noise plus pf

### DIFF
--- a/lagrangebench/case_setup/case.py
+++ b/lagrangebench/case_setup/case.py
@@ -150,7 +150,7 @@ def case_builder(
         neighbors: Optional[NeighborList] = None,
         is_allocate: bool = False,
         mode: str = "train",
-        **kwargs,  # key, noise_std
+        **kwargs,  # key, noise_std, unroll_steps
     ) -> Union[TrainCaseOut, EvalCaseOut]:
         pos_input = jnp.asarray(sample[0], dtype=dtype)
         particle_type = jnp.asarray(sample[1])

--- a/lagrangebench/train/strats.py
+++ b/lagrangebench/train/strats.py
@@ -38,7 +38,7 @@ def add_gns_noise(
         shift_fn: Shift function.
     """
     isl = input_seq_length
-    # random-walk noise in the velocity applied to the position sequence w/o pushforward
+    # random-walk noise in the velocity applied to the first input_seq_length positions
     key, pos_input_noise = _get_random_walk_noise_for_pos_sequence(
         key, pos_input[:, :input_seq_length], noise_std_last_step=noise_std
     )

--- a/lagrangebench/train/trainer.py
+++ b/lagrangebench/train/trainer.py
@@ -292,7 +292,7 @@ def Trainer(
 
                 key, unroll_steps = push_forward_sample_steps(key, step, pushforward)
                 # target computation incorporates the sampled number pushforward steps
-                keys, features_batch, target_batch, neighbors_batch = preprocess_vmap(
+                _keys, features_batch, target_batch, neighbors_batch = preprocess_vmap(
                     keys,
                     raw_batch,
                     noise_std,
@@ -302,6 +302,9 @@ def Trainer(
                 # unroll for push-forward steps
                 _current_pos = raw_batch[0][:, :, :input_seq_length]
                 for _ in range(unroll_steps):
+                    if neighbors_batch.did_buffer_overflow.sum() > 0:
+                        print(f"Overflowed neighbor list at push-forward, step {step}")
+                        break
                     _current_pos, neighbors_batch, features_batch = push_forward_vmap(
                         features_batch,
                         _current_pos,
@@ -314,18 +317,19 @@ def Trainer(
                 if neighbors_batch.did_buffer_overflow.sum() > 0:
                     # check if the neighbor list is too small for any of the samples
                     # if so, reallocate the neighbor list
-                    ind = jnp.argmax(neighbors_batch.did_buffer_overflow)
-                    edges_ = neighbors_batch.idx[ind].shape
-                    print(f"Reallocate neighbors list {edges_} at step {step}")
-                    sample = broadcast_from_batch(raw_batch, index=ind)
-                    _, _, _, nbrs = case.allocate(keys[0], sample)
-                    print(f"To list {nbrs.idx.shape}")
 
+                    print(f"Reallocate neighbors list at step {step}")
+                    ind = jnp.argmax(neighbors_batch.did_buffer_overflow)
+                    sample = broadcast_from_batch(raw_batch, index=ind)
+
+                    _, _, _, nbrs = case.allocate(keys[ind], sample, noise_std)
+                    print(f"From {neighbors_batch.idx[ind].shape} to {nbrs.idx.shape}")
                     neighbors_batch = broadcast_to_batch(nbrs, loader_train.batch_size)
 
                     # To run the loop N times even if sometimes
                     # did_buffer_overflow > 0 we directly return to the beginning
                     continue
+                keys = _keys
 
                 loss, params, state, opt_state = update_fn(
                     params=params,


### PR DESCRIPTION
1. Previously, the random-walk noise was drawn for the full positions sequence, and for entries corresponding to the target position and potential pushforward positions the noise was set to zero. However, the noise seed resulted in different outputs with different pushforward max unroll steps. 
2. There is a rescaling factor on the noise std being related to the sequence length (file `lagrangebench/train/strats.py`, line `velocity_sequence_noise *= noise_std_last_step / (n_velocities**0.5)`). Until now, the `n_velocities` for this rescaling was defined as `input_seq_length + pushforward["unrolls"][-1]`, e.g. 6 in the case of 5 past velocities and no pushforward, and then more depending on pushforward. This caused lower noise magnitude as soon as there was pushforward.

Now, in both cases (with or without pushforward), the noise is drawn only for the past 5 historic velocities, and the noise std rescaling factor is 5 (which is the actual number of past velocities, not past positions). 
-> **This rescaling factor will probably mess up the baseline results from the NeurIPS paper**, but it is the better way to move on.